### PR TITLE
Update dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.11,<3.12"
 dynamic = ["version"]
 license = {file = "LICENSE.txt"}
 dependencies = [
-    "pandas>=1.5,<2.0.1",
+    "pandas>=1.5,<2.0",
     "sqlalchemy>=1.4,<2.0",
     "catalystcoop-pudl @ git+https://github.com/catalyst-cooperative/pudl@140627f6f6b01cf75e8571dd9beb54244de0c6f3",
     "splink>=3.7.2,<4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.11,<3.12"
 dynamic = ["version"]
 license = {file = "LICENSE.txt"}
 dependencies = [
-    "pandas>=1.5,<2.0",
+    "pandas>=1.5,<2.0.1",
     "sqlalchemy>=1.4,<2.0",
     "catalystcoop-pudl @ git+https://github.com/catalyst-cooperative/pudl@140627f6f6b01cf75e8571dd9beb54244de0c6f3",
     "splink>=3.7.2,<4.0",
@@ -42,7 +42,7 @@ keywords = []
 
 [project.optional-dependencies]
 dev = [
-    "black>=22.0,<23.2",  # A deterministic code formatter
+    "black>=22.0,<23.4",  # A deterministic code formatter
     "isort>=5.0,<5.13",  # Standardized import sorting
     "tox>=3.20,<4.5",  # Python test environment manager
     "twine>=3.3,<4.1",  # Used to make releases to PyPI
@@ -51,7 +51,7 @@ docs = [
     "doc8>=0.9,<1.2",  # Ensures clean documentation formatting
     "furo>=2022.4.7",
     "sphinx>=4,!=5.1.0,<6.1.4",  # The default Python documentation engine
-    "sphinx-autoapi>=1.8,<2.1",  # Generates documentation from docstrings
+    "sphinx-autoapi>=1.8,<2.2",  # Generates documentation from docstrings
     "sphinx-issues>=1.2,<3.1",  # Allows references to GitHub issues
 ]
 tests = [
@@ -66,7 +66,7 @@ tests = [
     "flake8-use-fstring>=1.0,<1.5",  # Highlight use of old-style string formatting
     "jupyter", # For integration testing Jupyter notebooks
     "mccabe>=0.6,<0.8",  # Checks that code isn't overly complicated
-    "mypy>=0.942,<1.2",  # Static type checking
+    "mypy>=0.942,<1.3",  # Static type checking
     "nbconvert>=7,<8",
     "nbformat>=5,<6",
     "pep8-naming>=0.12,<0.14",  # Require PEP8 compliant variable names


### PR DESCRIPTION
Dependabot made a bunch of PRs while the CI was failing that didn't get merged. Now that I've switched to using `pyproject.toml` I'm moving those version updates over to this PR and closing the old dependabot PRs.