### PR TITLE
pin pudl back to dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = {file = "LICENSE.txt"}
 dependencies = [
     "pandas>=1.5,<2.0",
     "sqlalchemy>=1.4,<2.0",
-    "catalystcoop-pudl @ git+https://github.com/catalyst-cooperative/pudl@140627f6f6b01cf75e8571dd9beb54244de0c6f3",
+    "catalystcoop-pudl @ git+https://github.com/catalyst-cooperative/pudl@dev",
     "splink>=3.7.2,<4.0",
 ]
 classifiers = [


### PR DESCRIPTION
Hopefully soon we'll run a nightly build off the `main` branch of PUDL so that this dependency can be pinned to `main`. But for now pin back to `dev`.