### PR TITLE
updates tox-pytest for checking cache and download pudl db

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -49,12 +49,25 @@ jobs:
           path: ~/pudl-work/output/pudl.sqlite
           key: ${{ steps.get-date.outputs.date }}
 
-      - name: Download PUDL DB and log pre-test PUDL workspace contents
+      - name: Check Cache and Download PUDL DB
         if: steps.cache-db.outputs.cache-hit != 'true'
         run: |
-          mkdir -p ~/pudl-work/output/
-          curl -o ~/pudl-work/output/pudl.sqlite http://intake.catalyst.coop.s3.amazonaws.com/dev/pudl.sqlite
-          find ~/pudl-work/
+          if [ -f commit_hash.txt ] && [ -f sha256_hash.txt ]; then
+            CACHED_COMMIT_HASH=$(cat commit_hash.txt)
+            CACHED_SHA256_HASH=$(cat sha256_hash.txt)
+            if [ "$CACHED_COMMIT_HASH" = "$GITHUB_SHA" ] && [ "$CACHED_SHA256_HASH" = "$(python -c "import hashlib; m = hashlib.sha256(); m.update(open('~/pudl-work/output/pudl.sqlite', 'rb').read()); print(m.hexdigest())")" ]; then
+              echo "Cache is up to date. Skipping download."
+            else
+              echo "Cache is outdated. Downloading a new DB."
+              # Download the PUDL DB here
+              curl -o ~/pudl-work/output/pudl.sqlite http://intake.catalyst.coop.s3.amazonaws.com/dev/pudl.sqlite
+            fi
+          else
+            echo "Cache is missing. Downloading a new DB."
+            # Download the PUDL DB here
+            curl -o ~/pudl-work/output/pudl.sqlite http://intake.catalyst.coop.s3.amazonaws.com/dev/pudl.sqlite
+          fi
+          find ~/pudl-work/  
 
       - name: Log SQLite3 version
         run: |


### PR DESCRIPTION
**Issue #2461** : Have nightly builds output cache keys when successful 

**Enhancement**: Add Nightly Builds Output Cache Keys

This pull request aims to enhance the workflow for handling Nightly Builds Output in our repository by introducing cache keys. The goal is to optimize the downloading process and reduce unnecessary downloads of the PUDL DB.

**Changes Made**:

- Added cache-checking logic to determine if the cache is up to date.
- Calculated the SHA256 hash of the downloaded PUDL DB.
- Compared the cached SHA256 hash with the hash of the downloaded DB to decide whether to download a new DB.
- Incorporated the latest download logic for the PUDL DB.

**Why This Enhancement**:
The introduction of cache keys improves the efficiency of the CI workflow by only downloading a new PUDL DB when necessary. This change can significantly speed up the CI process and save resources by avoiding redundant downloads.

**Checklist**:
 

- [ ] Code is tested and functions correctly.
- [ ] Comments and documentation are updated where necessary.
- [ ] Code follows best practices and coding standards.

Please review this pull request, and your feedback and suggestions are welcome.




